### PR TITLE
Exclude the dir "StRoot/CVS" for libraries.

### DIFF
--- a/cmake/blacklisted_lib_dirs.txt
+++ b/cmake/blacklisted_lib_dirs.txt
@@ -37,3 +37,4 @@ StRoot/StSpinPool         # blacklisted in cons
 StRoot/StStrangePool      # blacklisted in cons
 StRoot/StSvtPool          # requires subdir processing
 StRoot/StTofPool          # blacklisted in cons?
+StRoot/CVS


### PR DESCRIPTION
Cmake tries to create a target "CVS" if using the default STAR_SRC = "$ENV{STAR}".